### PR TITLE
feat(e2e-test-forwarder): add command line arguments using clap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1173,6 +1173,7 @@ dependencies = [
 name = "e2e-test-forwarder"
 version = "0.1.0"
 dependencies = [
+ "clap 4.3.19",
  "edgehog-device-runtime-forwarder",
  "tokio",
  "tracing",

--- a/e2e-test-forwarder/Cargo.toml
+++ b/e2e-test-forwarder/Cargo.toml
@@ -11,6 +11,7 @@ rust-version.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = { workspace = true, features = ["derive"] }
 edgehog-forwarder = { workspace = true, features = ["_test-utils"]}
 tokio = {workspace = true}
 tracing = {workspace = true}

--- a/e2e-test-forwarder/src/main.rs
+++ b/e2e-test-forwarder/src/main.rs
@@ -1,20 +1,34 @@
 // Copyright 2023 SECO Mind Srl
 // SPDX-License-Identifier: Apache-2.0
 
+use clap::Parser;
 use tokio::task::JoinSet;
 use tracing::info;
+
+#[derive(Parser, Debug)]
+struct Cli {
+    /// Host address of the forwarder server
+    #[arg(long, short = 'H')]
+    host: String,
+    /// Port of the forwarder server
+    #[arg(short, long, default_value_t = 4000)]
+    port: u16,
+    /// Session token
+    #[arg(short, long)]
+    token: String
+}
 
 #[tokio::main]
 async fn main() {
     use edgehog_forwarder::test_utils::con_manager;
+    let Cli{host, port, token} = Cli::parse();
 
     tracing_subscriber::fmt::init();
 
+    let url = format!("ws://{host}:{port}/device/websocket?session={token}");
     let mut js = JoinSet::new();
 
-    js.spawn(con_manager(
-        "ws://kaiki.local:4000/device/websocket?session=abcd".to_string(),
-    ));
+    js.spawn(con_manager(url));
 
     while let Some(res) = js.join_next().await {
         info!("{res:?}");


### PR DESCRIPTION
adds the ability to customize connection parameters at runtime, including
- host
- port
- session token